### PR TITLE
Fix live reload not working on Windows

### DIFF
--- a/lib/pluginHook.js
+++ b/lib/pluginHook.js
@@ -41,12 +41,13 @@ module.exports = function(context) {
         });
 
         defaults.server = {
-            baseDir: platforms.map(patcher.getWWWFolder.bind(patcher)),
+            baseDir: [],
             routes: {}
         }
 
         platforms.forEach(function(platform) {
             var www = patcher.getWWWFolder(platform);
+            defaults.server.baseDir.push(path.join(www));
             defaults.server.routes['/' + www] = path.join(context.opts.projectRoot, www);
         });
 

--- a/lib/utils/Patcher.js
+++ b/lib/utils/Patcher.js
@@ -86,7 +86,7 @@ Patcher.prototype.updateConfigXml = function() {
         if (contentTag) {
             contentTag.attrib.src = START_PAGE;
         }
-        // Also add allow nav in case of 
+        // Also add allow nav in case of
         var allowNavTag = et.SubElement(configXml.find('.'), 'allow-navigation');
         allowNavTag.set('href', '*');
         fs.writeFileSync(filename, configXml.write({
@@ -116,7 +116,7 @@ Patcher.prototype.patch = function(opts) {
 };
 
 Patcher.prototype.getWWWFolder = function(platform) {
-    return path.join('platforms', platform, WWW_FOLDER[platform]);
+    return ['platforms', platform, WWW_FOLDER[platform]].join('/');
 };
 
 module.exports = Patcher;


### PR DESCRIPTION
patcher.getWWWFolder() was returning the path with backslashes on Windows, but some callers of the code assumed it returned slashes, and used it to form URLs.

I modified patcher.getWWWFolder() to always return the path with slashes, and any caller that needs a filesystem path will run it through path.join() to convert to the proper OS delimiter 