### PR TITLE
fix #15 ignore parsing errors for binary plists

### DIFF
--- a/lib/utils/Patcher.js
+++ b/lib/utils/Patcher.js
@@ -100,12 +100,16 @@ Patcher.prototype.updateConfigXml = function() {
 
 Patcher.prototype.fixATS = function() {
     return this.__forEachFile('**/*Info.plist', CONFIG_LOCATION, function(filename) {
-        var data = plist.parse(fs.readFileSync(filename, 'utf-8'));
-        data.NSAppTransportSecurity = {
-            NSAllowsArbitraryLoads: true
-        };
-        fs.writeFileSync(filename, plist.build(data));
-        //console.log('Fixed ATS in ', filename);
+        try {
+            var data = plist.parse(fs.readFileSync(filename, 'utf-8'));
+            data.NSAppTransportSecurity = {
+                NSAllowsArbitraryLoads: true
+            };
+            fs.writeFileSync(filename, plist.build(data));
+            //console.log('Fixed ATS in ', filename);
+        } catch (err) {
+            console.log('Error when parsing', filename, err);
+        }
     });
 };
 


### PR DESCRIPTION
- when trying to patch a binary plist file parsing will throw an exception
- since such files should usually not be patched, we simply ignore those
  files