### PR TITLE
added the option to enable cors in browsersync server, to support the…

### DIFF
--- a/lib/pluginHook.js
+++ b/lib/pluginHook.js
@@ -20,7 +20,7 @@ module.exports = function(context) {
     if (typeof options['live-reload'] === 'undefined') {
         return;
     }
-
+    var enableCors = typeof options['enable-cors']!='undefined';
     // TODO - Add back ignored option
     // TODO - Enable live reload servers
 
@@ -29,6 +29,12 @@ module.exports = function(context) {
     var changesBuffer = [];
     var changesTimeout;
     var bs = browserSyncServer(function(defaults) {
+        if (enableCors){
+            defaults.middleware = function (req, res, next) {
+              res.setHeader('Access-Control-Allow-Origin', '*');
+              next();
+            }
+        }
         defaults.files.push({
             match: ['www/**/*.*'],
             fn: function(event, file) {


### PR DESCRIPTION
I added the option to enable cors in browsersync server, to support the cordova browser platform. The browser platform starts typically on port 8000, and rejects the ajax to browserSync server running on port 3000 unless the cors is set
 to enable the cors --enable-cors option is used: cordova run -- --live-reload --enable-cors
