### PR TITLE
Allow manual specification of external host.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ cordova run -- --live-reload --ignore=lib/**/*.*
 ```
 
 The `--ignore` commands takes an [anymatch](https://github.com/es128/anymatch) compatible destination relative to the `www` folder.
+
+### Setting custom hostname
+Sometimes, depending on your network, your OS will report multiple external IP addresses. If this happens, by default browsersync just picks the first one and hopes for the best.
+
+To override this behaviour and manually select which host you want to use for the external interface, use the `--host` option, for example:
+
+```
+cordova run -- --live-reload --host=192.168.1.1
+```

--- a/lib/pluginHook.js
+++ b/lib/pluginHook.js
@@ -66,6 +66,10 @@ module.exports = function(context) {
             routes: {}
         }
 
+        if (typeof options['host'] !== 'undefined') {
+            defaults.host = options['host'];
+        }
+
         platforms.forEach(function(platform) {
             var www = patcher.getWWWFolder(platform);
             defaults.server.routes['/' + www.replace('\\','/')] = path.join(context.opts.projectRoot, www);


### PR DESCRIPTION
Resolves https://github.com/nparashuram/cordova-plugin-browsersync/issues/18.
See https://browsersync.io/docs#external-url.