### PR TITLE
Add browsersync online option

### DIFF
--- a/lib/pluginHook.js
+++ b/lib/pluginHook.js
@@ -70,6 +70,10 @@ module.exports = function(context) {
             defaults.host = options['host'];
         }
 
+        if (typeof options['online'] !== 'undefined') {
+            defaults.online = options['online'].toLocaleLowerCase() !== 'false';
+        }
+
         platforms.forEach(function(platform) {
             var www = patcher.getWWWFolder(platform);
             defaults.server.routes['/' + www.replace('\\','/')] = path.join(context.opts.projectRoot, www);


### PR DESCRIPTION
Within the proxy, BrowserSync will not work unless you add the `online=true` option. Add `--online` option to cordova-plugin-browsersync.

If `online = true` is not set, it becomes only localhost, it will not be able to detect external ip.