### PR TITLE
WIP: Wait for browsersync started

### DIFF
--- a/lib/pluginHook.js
+++ b/lib/pluginHook.js
@@ -15,6 +15,9 @@ function parseOptions(opts) {
 }
 
 module.exports = function(context) {
+    var Q = context.requireCordovaModule('q');
+    var deferral = new Q.defer();
+
     var options = parseOptions(context.opts.options.argv);
     options['index'] = typeof options['index'] !== 'undefined' ? options['index'] : 'index.html';
 
@@ -92,5 +95,8 @@ module.exports = function(context) {
             servers: servers,
             index: options.index
         });
+        deferral.resolve();
     });
+
+    return deferral.promise;
 }


### PR DESCRIPTION
The launch of Browsersync is delayed, and the application may be built before rewriting config.xml.

This patch blocks the build of the application until rewriting config.xml.