### PR TITLE
added https option of browser-sync

### DIFF
--- a/lib/utils/browserSyncServer.js
+++ b/lib/utils/browserSyncServer.js
@@ -52,6 +52,7 @@ module.exports = function(opts, cb) {
         minify: false,
         watchOptions: {},
         files: [],
+        https: true,
     };
 
     if (typeof opts === 'function') {


### PR DESCRIPTION
Because of browser-sync, cordova use LAN IP address (e.g. 192.168.0.100) instead of localhost on devices. Some powerful features such as getUserMedia() no longer works on insecure origins. This patch solves simply the problem by adding https option to BrowserSync.init options.

related: #30