### PR TITLE
Fix Android livereload + CSP building

### DIFF
--- a/lib/pluginHook.js
+++ b/lib/pluginHook.js
@@ -37,6 +37,7 @@ module.exports = function(context) {
     patcher.prepatch();
     var changesBuffer = [];
     var changesTimeout;
+    var serversFromCallback=[];
     var bs = browserSyncServer(function(defaults) {
         if (enableCors){
             defaults.middleware = function (req, res, next) {
@@ -55,7 +56,8 @@ module.exports = function(context) {
                     changesTimeout = setTimeout(function(){
                       context.cordova.raw.prepare().then(function() {
                           patcher.addCSP({
-                              index: options.index
+                              index: options.index,
+                              servers: serversFromCallback, //need this for building proper CSP
                           });
                           console.info(changesBuffer);
                           bs.reload(changesBuffer);
@@ -95,6 +97,7 @@ module.exports = function(context) {
 
         return defaults;
     }, function(err, servers) {
+        serversFromCallback=servers;
         patcher.patch({
             servers: servers,
             index: options.index

--- a/lib/utils/Patcher.js
+++ b/lib/utils/Patcher.js
@@ -10,13 +10,13 @@ var plist = require('plist');
 
 
 var WWW_FOLDER = {
-    android: 'assets/www',
+    android: 'app/src/main/assets/www',
     ios: 'www',
     browser:'www'
 };
 
 var CONFIG_LOCATION = {
-    android: 'res/xml',
+    android: 'app/src/main/res/xml',
     ios: '.',
     browser:'.'
 };
@@ -57,6 +57,11 @@ Patcher.prototype.addCSP = function(opts) {
         var policy = new Policy(cspTag.attr('content'));
         policy.add('default-src', 'ws:');
         policy.add('default-src', "'unsafe-inline'");
+        for (var key in opts.servers) {
+            if (typeof opts.servers[key] !== 'undefined') {
+                policy.add('script-src', opts.servers[key]);
+            }
+        }
         cspTag.attr('content', function() {
             return policy.toString();
         });


### PR DESCRIPTION
This MR fixes the livereload functionality on Android on newer Cordova versions (bug root cause: outdated base paths for config.xml/index.html), and CSP-related errors in case the developer has installed a restrictive script-src directive.